### PR TITLE
Fix build re enable nuget flow

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -14,7 +14,7 @@ let configuration = "Release"
 
 // Directories
 let output = __SOURCE_DIRECTORY__  @@ "bin"
-let outputTests = output @@ "tests"
+let outputTests = output @@ "TestResults"
 let outputBinaries = output @@ "binaries"
 let outputNuGet = output @@ "nuget"
 

--- a/build.fsx
+++ b/build.fsx
@@ -209,6 +209,7 @@ Target "Nuget" DoNothing
 
 // nuget dependencies
 "Clean" ==> "RestorePackages" ==> "Build" ==> "CreateNuget"
+"CreateNuget" ==> "PublishNuget" ==> "Nuget"
 
 // all
 Target "All" DoNothing


### PR DESCRIPTION
Upgrading the build process to build .net standard libs in my previous [PR: Upgrade to 1.3.1 #10](https://github.com/AkkaNetContrib/Akka.DI.Ninject/pull/10) used different names for some build targets and as a result nuget packages are not longer being created as part of the project's teamcity build, this new PR should address this issue.